### PR TITLE
Add supabase session and cart for mobile

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -61,6 +61,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="cart.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="account"
+        options={{
+          title: 'Account',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="person.fill" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/mobile/app/(tabs)/account.tsx
+++ b/mobile/app/(tabs)/account.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { Text, TextInput, Button, StyleSheet } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { useAuthCart } from '@/components/AuthCartProvider';
+
+export default function AccountScreen() {
+  const { session, signIn, signOut } = useAuthCart();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  if (session) {
+    return (
+      <Animated.View style={styles.container} entering={FadeIn} exiting={FadeOut}>
+        <Text style={styles.text}>Signed in as {session.user.email}</Text>
+        <Button title="Sign Out" onPress={signOut} />
+      </Animated.View>
+    );
+  }
+
+  return (
+    <Animated.View style={styles.container} entering={FadeIn} exiting={FadeOut}>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <Button title="Sign In" onPress={() => signIn(email, password)} />
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12 },
+  text: { fontSize: 18 },
+  input: {
+    borderWidth: 1,
+    padding: 8,
+    width: '80%',
+    borderRadius: 4,
+  },
+});

--- a/mobile/app/(tabs)/cart.tsx
+++ b/mobile/app/(tabs)/cart.tsx
@@ -1,14 +1,50 @@
-import { View, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet, FlatList, TouchableOpacity, LayoutAnimation } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { useAuthCart } from '@/components/AuthCartProvider';
 
 export default function CartScreen() {
+  const { cart, removeFromCart } = useAuthCart();
+
+  const handleRemove = async (id: string) => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    await removeFromCart(id);
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Cart Screen</Text>
-    </View>
+    <Animated.View style={styles.container} entering={FadeIn} exiting={FadeOut}>
+      {cart.length === 0 ? (
+        <Text style={styles.text}>Your cart is empty</Text>
+      ) : (
+        <FlatList
+          data={cart}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <Animated.View
+              style={styles.item}
+              entering={FadeIn}
+              exiting={FadeOut}
+            >
+              <Text style={styles.itemText}>{item.product_id}</Text>
+              <TouchableOpacity onPress={() => handleRemove(item.id)}>
+                <Text style={styles.remove}>Remove</Text>
+              </TouchableOpacity>
+            </Animated.View>
+          )}
+        />
+      )}
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  text: { fontSize: 20 },
+  container: { flex: 1, padding: 16 },
+  text: { fontSize: 20, textAlign: 'center', marginTop: 40 },
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  itemText: { fontSize: 16 },
+  remove: { color: 'red' },
 });

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -4,17 +4,20 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { AuthCartProvider } from '@/components/AuthCartProvider';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <AuthCartProvider>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </AuthCartProvider>
   );
 }

--- a/mobile/components/AuthCartProvider.tsx
+++ b/mobile/components/AuthCartProvider.tsx
@@ -1,0 +1,92 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { LayoutAnimation } from 'react-native';
+import { Session } from '@supabase/supabase-js';
+import { supabase } from '@/lib/supabase';
+
+export interface CartItem {
+  id: string;
+  product_id: string;
+  quantity: number;
+}
+
+interface AuthCartContextProps {
+  session: Session | null;
+  cart: CartItem[];
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  addToCart: (productId: string, quantity?: number) => Promise<void>;
+  removeFromCart: (id: string) => Promise<void>;
+}
+
+const AuthCartContext = createContext<AuthCartContextProps | undefined>(undefined);
+
+export function AuthCartProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [cart, setCart] = useState<CartItem[]>([]);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+    });
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, sess) => {
+      setSession(sess);
+    });
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (session?.user) {
+      fetchCart();
+    } else {
+      setCart([]);
+    }
+  }, [session]);
+
+  const fetchCart = async () => {
+    if (!session?.user) return;
+    const { data } = await supabase
+      .from('cart_items')
+      .select('*')
+      .eq('user_id', session.user.id);
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setCart(data || []);
+  };
+
+  const signIn = async (email: string, password: string) => {
+    await supabase.auth.signInWithPassword({ email, password });
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  const addToCart = async (productId: string, quantity = 1) => {
+    if (!session?.user) return;
+    await supabase.from('cart_items').insert({
+      user_id: session.user.id,
+      product_id: productId,
+      quantity,
+    });
+    await fetchCart();
+  };
+
+  const removeFromCart = async (id: string) => {
+    await supabase.from('cart_items').delete().eq('id', id);
+    await fetchCart();
+  };
+
+  return (
+    <AuthCartContext.Provider value={{ session, cart, signIn, signOut, addToCart, removeFromCart }}>
+      {children}
+    </AuthCartContext.Provider>
+  );
+}
+
+export function useAuthCart() {
+  const context = useContext(AuthCartContext);
+  if (!context) throw new Error('useAuthCart must be used within AuthCartProvider');
+  return context;
+}
+


### PR DESCRIPTION
## Summary
- add `AuthCartProvider` to sync Supabase session and cart
- show animated cart items
- add new Account screen
- wrap layout with provider and add Account tab

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-config-expo/flat')*

------
https://chatgpt.com/codex/tasks/task_e_6841c22c35548320b72aaf405ec20cf6