### PR TITLE
Clean mobile tab screens

### DIFF
--- a/mobile/app/(tabs)/cart.tsx
+++ b/mobile/app/(tabs)/cart.tsx
@@ -1,9 +1,7 @@
 
-import { Text, StyleSheet, FlatList, TouchableOpacity, LayoutAnimation } from 'react-native';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, LayoutAnimation } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { useAuthCart } from '@/components/AuthCartProvider';
-=======
-import { View, Text, StyleSheet } from 'react-native';
 import AnimatedSection from '@/components/AnimatedSection';
 
 
@@ -16,11 +14,11 @@ export default function CartScreen() {
   };
 
   return (
-
-    <Animated.View style={styles.container} entering={FadeIn} exiting={FadeOut}>
-      {cart.length === 0 ? (
-        <Text style={styles.text}>Your cart is empty</Text>
-      ) : (
+    <>
+      <Animated.View style={styles.container} entering={FadeIn} exiting={FadeOut}>
+        {cart.length === 0 ? (
+          <Text style={styles.text}>Your cart is empty</Text>
+        ) : (
         <FlatList
           data={cart}
           keyExtractor={(item) => item.id}
@@ -38,13 +36,14 @@ export default function CartScreen() {
           )}
         />
       )}
-    </Animated.View>
+      </Animated.View>
 
-    <AnimatedSection animation="fadeIn">
-      <View style={styles.container}>
-        <Text style={styles.text}>Cart Screen</Text>
-      </View>
-    </AnimatedSection>
+      <AnimatedSection animation="fadeIn">
+        <View style={styles.container}>
+          <Text style={styles.text}>Cart Screen</Text>
+        </View>
+      </AnimatedSection>
+    </>
   );
 }
 

--- a/mobile/app/(tabs)/catalog.tsx
+++ b/mobile/app/(tabs)/catalog.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from 'react';
-import { FlatList, StyleSheet } from 'react-native';
+import { FlatList, View, Text, StyleSheet } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 import { Image } from 'expo-image';
 
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import { supabase } from '@/lib/supabase';
-=======
-import { View, Text, StyleSheet } from 'react-native';
 import AnimatedSection from '@/components/AnimatedSection';
 
 
@@ -50,26 +48,26 @@ export default function CatalogScreen() {
   }
 
   return (
-
-    <FlatList
-      data={products}
-      keyExtractor={(item) => item.id.toString()}
-      contentContainerStyle={styles.list}
-      renderItem={({ item }) => (
-        <Animated.View entering={FadeIn.duration(300)} style={styles.item}>
-          {item.image ? (
-            <Image source={{ uri: item.image }} style={styles.image} />
+    <>
+      <FlatList
+        data={products}
+        keyExtractor={(item) => item.id.toString()}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <Animated.View entering={FadeIn.duration(300)} style={styles.item}>
+            {item.image ? (
+              <Image source={{ uri: item.image }} style={styles.image} />
           ) : null}
           <ThemedText style={styles.title}>{item.title}</ThemedText>
         </Animated.View>
       )}
-    />
-    <AnimatedSection animation="fadeIn">
-      <View style={styles.container}>
-        <Text style={styles.text}>Catalog Screen</Text>
-      </View>
-    </AnimatedSection>
-
+      />
+      <AnimatedSection animation="fadeIn">
+        <View style={styles.container}>
+          <Text style={styles.text}>Catalog Screen</Text>
+        </View>
+      </AnimatedSection>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- remove leftover merge markers in mobile tabs
- consolidate imports and wrap root components in fragments for `cart.tsx` and `catalog.tsx`

## Testing
- `npm exec tsc -- -p mobile` *(fails: Cannot find module 'expo-router', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684feb3cb104832095a27ef34ef59952