### PR TITLE
Add mobile catalog components

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,6 +2,8 @@
 
 This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
 
+The mobile app now mirrors the main pages of the Next.js site. It includes catalog and product screens powered by Supabase and simple cart and account flows.
+
 ## Get started
 
 1. Install dependencies
@@ -24,6 +26,8 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    EXPO_PUBLIC_SUPABASE_URL=<your supabase url>
    EXPO_PUBLIC_SUPABASE_ANON_KEY=<your anon key>
    ```
+
+4. Open the Expo app and use the Catalog tab to load products from your Supabase database. Use the Cart and Account tabs to test adding items or signing in.
 
 In the output, you'll find options to open the app in a
 

--- a/mobile/app/(tabs)/catalog.tsx
+++ b/mobile/app/(tabs)/catalog.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { FlatList, View, Text, StyleSheet } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
-import { Image } from 'expo-image';
+import PromoGrid from '@/components/PromoGrid';
+import ProductCard, { Product } from '@/components/ProductCard';
 
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
@@ -11,27 +12,17 @@ import AnimatedSection from '@/components/AnimatedSection';
 
 export default function CatalogScreen() {
   const [loading, setLoading] = useState(true);
-  const [products, setProducts] = useState<{
-    id: number;
-    title: string;
-    image: string | null;
-  }[]>([]);
+  const [products, setProducts] = useState<Product[]>([]);
 
   useEffect(() => {
     const fetchProducts = async () => {
       const { data, error } = await supabase
         .from('products')
-        .select('id, title, images')
+        .select('id, title, price, images')
         .order('id');
 
       if (!error && data) {
-        setProducts(
-          data.map((p) => ({
-            id: p.id,
-            title: p.title,
-            image: Array.isArray(p.images) && p.images.length > 0 ? p.images[0] : null,
-          }))
-        );
+        setProducts(data as Product[]);
       }
       setLoading(false);
     };
@@ -53,14 +44,12 @@ export default function CatalogScreen() {
         data={products}
         keyExtractor={(item) => item.id.toString()}
         contentContainerStyle={styles.list}
+        ListHeaderComponent={<PromoGrid />}
         renderItem={({ item }) => (
           <Animated.View entering={FadeIn.duration(300)} style={styles.item}>
-            {item.image ? (
-              <Image source={{ uri: item.image }} style={styles.image} />
-          ) : null}
-          <ThemedText style={styles.title}>{item.title}</ThemedText>
-        </Animated.View>
-      )}
+            <ProductCard product={item} />
+          </Animated.View>
+        )}
       />
       <AnimatedSection animation="fadeIn">
         <View style={styles.container}>
@@ -75,6 +64,4 @@ const styles = StyleSheet.create({
   loadingContainer: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   list: { padding: 16 },
   item: { marginBottom: 16, alignItems: 'center' },
-  image: { width: 150, height: 150, borderRadius: 8, marginBottom: 8, backgroundColor: '#eee' },
-  title: { fontSize: 16, fontWeight: '600', textAlign: 'center' },
 });

--- a/mobile/components/ProductCard.tsx
+++ b/mobile/components/ProductCard.tsx
@@ -1,0 +1,55 @@
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Image } from 'expo-image';
+
+import { useAuthCart } from './AuthCartProvider';
+import { ThemedText } from './ThemedText';
+import { Colors } from '@/constants/Colors';
+
+export interface Product {
+  id: number;
+  title: string;
+  price: number;
+  images: string[] | null;
+}
+
+export default function ProductCard({ product }: { product: Product }) {
+  const { addToCart } = useAuthCart();
+  const image = Array.isArray(product.images) && product.images.length > 0 ? product.images[0] : null;
+  const handleAdd = () => addToCart(product.id.toString());
+
+  return (
+    <View style={styles.card}>
+      {image && <Image source={{ uri: image }} style={styles.image} contentFit="cover" />}
+      <ThemedText style={styles.title}>{product.title}</ThemedText>
+      <ThemedText style={styles.price}>{product.price} ₽</ThemedText>
+      <TouchableOpacity style={styles.button} onPress={handleAdd}>
+        <Text style={styles.buttonText}>Add to Cart</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: Colors.light.background,
+    borderRadius: 8,
+    padding: 12,
+    alignItems: 'center',
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+  },
+  image: { width: 150, height: 150, borderRadius: 8, marginBottom: 8, backgroundColor: '#eee' },
+  title: { fontSize: 16, fontWeight: '600', textAlign: 'center', color: Colors.light.text },
+  price: { fontSize: 14, color: Colors.light.text, marginVertical: 4 },
+  button: {
+    backgroundColor: Colors.light.text,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 4,
+    marginTop: 8,
+  },
+  buttonText: { color: Colors.light.background, fontWeight: 'bold' },
+});

--- a/mobile/components/PromoGrid.tsx
+++ b/mobile/components/PromoGrid.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { FlatList, View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Image } from 'expo-image';
+
+import { supabase } from '@/lib/supabase';
+import { ThemedText } from './ThemedText';
+import { Colors } from '@/constants/Colors';
+
+interface PromoBlock {
+  id: number;
+  title: string;
+  image_url: string;
+  href: string | null;
+}
+
+export default function PromoGrid() {
+  const [blocks, setBlocks] = useState<PromoBlock[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase
+        .from('promo_blocks')
+        .select('id, title, image_url, href')
+        .order('order_index');
+      if (data) setBlocks(data as PromoBlock[]);
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return <ThemedText>Loading...</ThemedText>;
+  }
+
+  return (
+    <FlatList
+      data={blocks}
+      keyExtractor={(item) => item.id.toString()}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={styles.list}
+      renderItem={({ item }) => (
+        <TouchableOpacity style={styles.item}>
+          <Image source={{ uri: item.image_url }} style={styles.image} contentFit="cover" />
+          <View style={styles.overlay}>
+            <ThemedText style={styles.title}>{item.title}</ThemedText>
+          </View>
+        </TouchableOpacity>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  list: { marginVertical: 16 },
+  item: {
+    width: 300,
+    height: 180,
+    marginRight: 16,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  image: { flex: 1 },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: { color: Colors.light.background, fontSize: 18, fontWeight: 'bold', textAlign: 'center' },
+});


### PR DESCRIPTION
## Summary
- add simple `ProductCard` and `PromoGrid` components for React Native
- show promo banners and product cards in the catalog screen
- document new mobile features and usage

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-config-expo/flat')*

------
https://chatgpt.com/codex/tasks/task_e_684fec85db9c8320b684ec526cdd91c1